### PR TITLE
Update to currently-supported macOS versions

### DIFF
--- a/Casks/vcmi.rb
+++ b/Casks/vcmi.rb
@@ -11,7 +11,7 @@ cask "vcmi" do
   desc "Open-source engine for Heroes of Might & Magic III"
   homepage "https://vcmi.eu/"
 
-  depends_on macos: ">= :high_sierra"
+  depends_on macos: ">= :sonoma"
 
   app "VCMI.app"
 

--- a/Casks/vcmi.rb
+++ b/Casks/vcmi.rb
@@ -11,7 +11,7 @@ cask "vcmi" do
   desc "Open-source engine for Heroes of Might & Magic III"
   homepage "https://vcmi.eu/"
 
-  depends_on macos: ">= :sonoma"
+  depends_on macos: ">= :catalina"
 
   app "VCMI.app"
 


### PR DESCRIPTION
Per https://github.com/Homebrew/brew/blob/main/Library/Homebrew/requirements/macos_requirement.rb#L17, High Sierra is no longer a valid version for Homebrew macOS version checks.  It's returning a warning (and will probably eventually break).

Catalina appears to be the earliest version that's still permitted, but I updated this to Sonoma, as it's the earliest version officially supported by the Homebrew project.